### PR TITLE
TOS links to naive GEX, price ratio, and volume

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -308,6 +308,10 @@ https://www.youtube.com/watch?v=fNk_zzaMoSs&list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE
   *   http://tos.mx/s4dE1f – Watch List symbols Morning Radar indices overview
   *   http://tos.mx/dh4WE4 – Watch List symbols New World
   *   http://tos.mx/MY2OOA – Watch List symbols optionable sector ETFs
+  *   https://tos.mx/HsRcAL8 – Option chain naive GEX calculation with thermometer color
+  *   https://tos.mx/f62FzIO - Option chain volume with thermometer color
+  *   https://tos.mx/dswMF9O - Option chain contract price as a ratio of underlying price
+
 
 ## Charts & Studies
   *   http://tos.mx/ozZx1u – alert Relative Vol Std Dev


### PR DESCRIPTION
Hey @stephen-netu -- thought that these links would be handy from my personal TOS stash :)

**Contract price as a ratio of underyling price (for those lepto seekers) including thermometer colors:**
![image](https://user-images.githubusercontent.com/6598675/151719431-183f5a62-e5d1-434d-9878-ecacf73adc9e.png)

**Naive GEX including thermometer colors:**
![image](https://user-images.githubusercontent.com/6598675/151719472-96578099-f76c-4729-a5c0-f8744a65788e.png)

**Volume with thermometer colors:**
![image](https://user-images.githubusercontent.com/6598675/151719502-2d05e331-3abe-458a-893c-2c768eea6ef0.png)
